### PR TITLE
tests_meego/: Fix hardcoded temporary directory path.

### DIFF
--- a/tests_meego/ChangeLogHandlerTest.cpp
+++ b/tests_meego/ChangeLogHandlerTest.cpp
@@ -43,7 +43,7 @@ using namespace DataSync;
 
 void ChangeLogHandlerTest::initTestCase()
 {
-    iDbHandler = new DatabaseHandler( "/tmp/changeloghandlertest.db" );
+    iDbHandler = new DatabaseHandler( QProcessEnvironment::systemEnvironment().value("TMPDIR", "/tmp") + "/changeloghandlertest.db" );
 
 }
 void ChangeLogHandlerTest::cleanupTestCase()

--- a/tests_meego/ChangeLogTest.cpp
+++ b/tests_meego/ChangeLogTest.cpp
@@ -41,8 +41,8 @@
 
 using namespace DataSync;
 
-const QString DB1( "/tmp/changelogtest1.db" );
-const QString DB2( "/tmp/changelogtest2.db" );
+const QString DB1( QProcessEnvironment::systemEnvironment().value("TMPDIR", "/tmp") + "/changelogtest1.db" );
+const QString DB2( QProcessEnvironment::systemEnvironment().value("TMPDIR", "/tmp") + "/changelogtest2.db" );
 
 void ChangeLogTest::initTestCase()
 {

--- a/tests_meego/NonceStorageTest.cpp
+++ b/tests_meego/NonceStorageTest.cpp
@@ -37,7 +37,7 @@
 #include "NonceStorage.h"
 
 
-const QString DB( "/tmp/noncestoragetest.db" );
+const QString DB( QProcessEnvironment::systemEnvironment().value("TMPDIR", "/tmp") + "/noncestoragetest.db" );
 const QString LOCALDEVICE( "localDevice" );
 const QString REMOTEDEVICE( "remoteDevice" );
 

--- a/tests_meego/SessionHandlerTest.cpp
+++ b/tests_meego/SessionHandlerTest.cpp
@@ -48,7 +48,7 @@
 
 using namespace DataSync;
 
-QString DBFILE( "/tmp/sessionhandlertest.db" );
+QString DBFILE( QProcessEnvironment::systemEnvironment().value("TMPDIR", "/tmp") + "/sessionhandlertest.db" );
 QString NB153701UNKNOWNDEVICE( "/" );
 QString NB153701SOURCEDEVICE( "IMEI:000000000000000" );
 QString NB153701TARGETDEVICE( "IMEI:000000000000001" );

--- a/tests_meego/SyncTargetTest.cpp
+++ b/tests_meego/SyncTargetTest.cpp
@@ -41,7 +41,7 @@ using namespace DataSync;
 
 void SyncTargetTest::initTestCase()
 {
-    iDbHandler = new DatabaseHandler( "/tmp/synctargettest.db");
+    iDbHandler = new DatabaseHandler( QProcessEnvironment::systemEnvironment().value("TMPDIR", "/tmp") + "/synctargettest.db");
     QString remoteDevice = "remotedevice";
     QString localDb = "localcontacts";
     const SyncMode syncMode;

--- a/tests_meego/clienttests/ClientSessionHandlerTest.cpp
+++ b/tests_meego/clienttests/ClientSessionHandlerTest.cpp
@@ -47,7 +47,7 @@ using namespace DataSync;
 
 void ClientSessionHandlerTest::initTestCase()
 {
-    iDbHandler = new DatabaseHandler( "/tmp/clientsessionhandler.db");
+    iDbHandler = new DatabaseHandler( QProcessEnvironment::systemEnvironment().value("TMPDIR", "/tmp") + "/clientsessionhandler.db");
     iClientId = QString("clientId");
     iConfig = new SyncAgentConfig();
     iTransport = new MockTransport(QString("data/transport_initrequest_nohdr.txt"));

--- a/tests_meego/servertests/ServerCommandHandlerTest.cpp
+++ b/tests_meego/servertests/ServerCommandHandlerTest.cpp
@@ -51,7 +51,7 @@ using namespace DataSync;
  */
 void ServerCommandHandlerTest::initTestCase()
 {
-    iDbHandler = new DatabaseHandler( "/tmp/servercommandhandlertest.db");
+    iDbHandler = new DatabaseHandler( QProcessEnvironment::systemEnvironment().value("TMPDIR", "/tmp") + "/servercommandhandlertest.db");
     iStorageHandler = new StorageHandler();
     iCommandHandler = new CommandHandler( MODE_SERVER );
     iRemoteDevice = "remotedevice";

--- a/tests_meego/servertests/ServerSessionHandlerTest.cpp
+++ b/tests_meego/servertests/ServerSessionHandlerTest.cpp
@@ -45,7 +45,7 @@
 
 using namespace DataSync;
 
-static QString DBFILE( "/tmp/serversessionhandler.db" );
+static QString DBFILE( QProcessEnvironment::systemEnvironment().value("TMPDIR", "/tmp") + "/serversessionhandler.db" );
 
 void ServerSessionHandlerTest::initTestCase()
 {


### PR DESCRIPTION
A number of tests hardcode /tmp and use it for temporary data which is not guaranteed to be writable during package builds leading to failed tests. Use the TMPDIR environment variable instead and fall back to /tmp if not set.